### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/backend/api/endpoints.py
+++ b/backend/api/endpoints.py
@@ -51,7 +51,15 @@ async def analyze_file(
         }
     
     # Save file
-    file_path = os.path.join(UPLOAD_DIR, f"{sha256}_{file.filename}")
+    original_name = file.filename or ""
+    safe_name = os.path.basename(original_name)
+    if not safe_name:
+        safe_name = "upload"
+    final_name = f"{sha256}_{safe_name}"
+    file_path = os.path.normpath(os.path.join(UPLOAD_DIR, final_name))
+    # Ensure the resolved path stays within the upload directory
+    if os.path.commonpath([UPLOAD_DIR, file_path]) != UPLOAD_DIR:
+        raise HTTPException(status_code=400, detail="Invalid filename")
     # Write async (stream when sha256 provided to avoid buffering whole file)
     async with aiofiles.open(file_path, "wb") as out_file:
         if "content" in locals():


### PR DESCRIPTION
Potential fix for [https://github.com/MICHAEL-888/Phantom_TrojanWalker/security/code-scanning/1](https://github.com/MICHAEL-888/Phantom_TrojanWalker/security/code-scanning/1)

General approach: Ensure any filesystem path derived from user input is safe by (1) sanitizing the filename portion to remove path separators and dangerous characters, and/or (2) normalizing the final path and verifying it remains inside a trusted root (`UPLOAD_DIR`). We should avoid changing behavior beyond security hardening.

Best specific fix here:

1. Sanitize the incoming upload filename using a well-known helper that strips path components and dangerous characters. Since we already use FastAPI/Starlette, we can safely import and use `starlette.datastructures.UploadFile`’s name or, more directly, use Werkzeug’s `secure_filename`. However, we must not add new external dependencies if we can reasonably avoid it. A minimal, safe change is to:
   - Extract only the basename of `file.filename` via `os.path.basename` to strip any user-supplied directory segments.
   - Optionally, fall back to a random safe name if the basename becomes empty.
2. Build the final filename as `f"{sha256}_{safe_filename}"`.
3. Construct `file_path = os.path.join(UPLOAD_DIR, final_name)`, then normalize and verify:
   - `full_path = os.path.normpath(file_path)`
   - Ensure `os.path.commonpath([UPLOAD_DIR, full_path]) == UPLOAD_DIR` to prevent traversal, even if separators slipped through.
4. Use `full_path` in `aiofiles.open` and when persisting `file_path` into the database.

This limits any path traversal via `file.filename` and guarantees the resolved path remains under `UPLOAD_DIR`, without changing the outward API or logic of the endpoint.

Concretely in `backend/api/endpoints.py`:

- After `# Save file`, replace the simple `file_path = os.path.join(UPLOAD_DIR, f"{sha256}_{file.filename}")` with:
  - compute `original_name = file.filename or ""`
  - `safe_name = os.path.basename(original_name)`
  - if `not safe_name`, generate a fallback like `safe_name = "upload"`
  - `final_name = f"{sha256}_{safe_name}"`
  - `file_path = os.path.normpath(os.path.join(UPLOAD_DIR, final_name))`
  - verify `os.path.commonpath([UPLOAD_DIR, file_path]) == UPLOAD_DIR`, otherwise raise `HTTPException(status_code=400, detail="Invalid filename")`.
- Use this validated `file_path` variable in the subsequent `aiofiles.open` and when assigning `file_path` to the `AnalysisTask`.

No new imports are necessary: `os.path` helpers are already available via `import os` (line 5).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
