### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/agents/analysis_coordinator.py
+++ b/agents/analysis_coordinator.py
@@ -172,8 +172,15 @@ class AnalysisCoordinator:
                     content = str(resp)
                 try:
                     analyses.append(json.loads(content))
-                except Exception as e:
-                    analyses.append({"error": f"Failed to parse JSON: {e}", "raw_response": content})
+                except Exception:
+                    # Log full exception details server-side, but do not expose them to the client.
+                    logger.error("Failed to parse JSON from LLM response", exc_info=True)
+                    analyses.append(
+                        {
+                            "error": "Failed to parse AI JSON response.",
+                            "raw_response": content,
+                        }
+                    )
 
             function_analysis_results = [
                 {"name": name, "analysis": analysis}


### PR DESCRIPTION
Potential fix for [https://github.com/MICHAEL-888/Phantom_TrojanWalker/security/code-scanning/2](https://github.com/MICHAEL-888/Phantom_TrojanWalker/security/code-scanning/2)

In general, to fix this, exception details (especially `str(e)` or formatted traces) should not be returned to the client. Instead, they should be logged on the server and replaced in responses with generic, non-sensitive messages. This preserves debuggability for developers while avoiding information exposure.

The best targeted fix here is to change the `except Exception as e` block at lines 175–176 in `agents/analysis_coordinator.py` so that: (1) it logs the parsing error with `logger.error(..., exc_info=True)` for developers, and (2) it appends a generic error structure to `analyses` that does not include `e` or other internal details. The rest of the data flow can remain unchanged; we only need to sanitize what gets inserted into `analyses`. No change is required in `agents/main.py`, because it already has safe global exception handlers and simply forwards the analysis result.

Concretely:
- In `agents/analysis_coordinator.py`, locate the `for resp in responses:` loop and the `except Exception as e:` block.
- Replace `analyses.append({"error": f"Failed to parse JSON: {e}", "raw_response": content})` with:
  - A logging call such as `logger.error("Failed to parse JSON from LLM response", exc_info=True)`; and
  - A generic error object like `{"error": "Failed to parse AI JSON response.", "raw_response": content}` (or similar), explicitly avoiding embedding `e`.
- No new imports are required because `logging` and `logger` are already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
